### PR TITLE
# Release Notes for **GHRD for Stratix 10 FPGA 25.3**

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is applicable to all designs.
   - SGMII with HPS EMAC and 1G/2.5G/5G/10G Multi-Rate Ethernet PHY Intel FPGA IP
 
 ## Dependency
-* Altera Quartus Prime 25.1.1
+* Altera Quartus Prime 25.3
 * Supported Board
   - Intel Stratix 10 SX SoC Development Kit
 

--- a/s10_soc_devkit_ghrd/create_ghrd_quartus.tcl
+++ b/s10_soc_devkit_ghrd/create_ghrd_quartus.tcl
@@ -748,5 +748,7 @@ set_instance_assignment -name SLEW_RATE 1 -to mux_io_1v8_20
 set_global_assignment -name PROMOTE_WARNING_TO_ERROR 332148
 # Promote pins without location assignments to errors
 set_global_assignment -name PROMOTE_WARNING_TO_ERROR 12677
+#Disable message 19958 due to ENABLE_NO_HIPI_INITIALIZATION_FLOW; Refer HSD:14022937742
+set_global_assignment -name MESSAGE_DISABLE 19958
 
 project_close


### PR DESCRIPTION
## Release Information:
Quartus Version: 25.3 Build 109 09/24/2025 SC Pro Edition
Tag: QPDS25.3_REL_GSRD_PR
Build: socfpga_ghrd_s10_base/25.3/300

## New Features and Enhancements
None

## Issues Resolved
* Disable message 19958 due to ENABLE_NO_HIPI_INITIALIZATION_FLOW

## Latest Known Issues
None