### PR TITLE
## Release Notes for **GHRD for Stratix 10 FPGA 26.1**

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,7 @@ $(strip $(2))-package-design: | $(strip $(5))
 
 .PHONY: $(strip $(2))-build
 $(strip $(2))-build: | $(strip $(1))/output_files
-	cd $(strip $(1)) && quartus_syn $(strip $(3))
-	cd $(strip $(1)) && quartus_fit $(strip $(3))
-	cd $(strip $(1)) && quartus_asm $(strip $(3))
-	cd $(strip $(1)) && quartus_sta $(strip $(3)) --mode=finalize
+	cd $(strip $(1)) && quartus_sh --flow compile $(strip $(3)) -c $(strip $(3))
 
 .PHONY: $(strip $(2))-sw-build
 $(strip $(2))-sw-build:
@@ -123,6 +120,7 @@ endef
 # Stratix 10
 $(eval $(call create_legacy_ghrd_target, s10_soc_devkit_ghrd, s10-htile-soc-devkit-oobe-baseline, ghrd_1sx280hu2f50e1vgas, generate-s10-htile-soc-devkit-oobe-baseline, $(INSTALL_ROOT)/designs))
 $(eval $(call create_legacy_ghrd_target, s10_soc_devkit_ghrd, s10-htile-soc-devkit-nand-baseline, ghrd_1sx280hu2f50e1vgas, generate-s10-htile-soc-devkit-nand-baseline, $(INSTALL_ROOT)/designs))
+$(eval $(call create_legacy_ghrd_target, s10_soc_devkit_ghrd, s10-htile-soc-devkit-emmc-baseline, ghrd_1sx280hu2f50e1vgas, generate-s10-htile-soc-devkit-emmc-baseline, $(INSTALL_ROOT)/designs))
 
 ###############################################################################
 #                          UTILITY TARGETS
@@ -219,6 +217,7 @@ endef
 # Stratix 10
 $(eval $(call create_fsbl_insertion_target, s10_soc_devkit_ghrd, s10-htile-soc-devkit-oobe-baseline, ghrd_1sx280hu2f50e1vgas, $(S10_FSBL_IHEX), hps_debug, $(INSTALL_ROOT)/designs))
 $(eval $(call create_fsbl_insertion_target, s10_soc_devkit_ghrd, s10-htile-soc-devkit-nand-baseline, ghrd_1sx280hu2f50e1vgas, $(S10_FSBL_IHEX), hps_debug, $(INSTALL_ROOT)/designs))
+$(eval $(call create_fsbl_insertion_target, s10_soc_devkit_ghrd, s10-htile-soc-devkit-emmc-baseline, ghrd_1sx280hu2f50e1vgas, $(S10_FSBL_IHEX), hps_debug, $(INSTALL_ROOT)/designs))
 
 # Include not_shipped Makefile if present
 -include not_shipped/Makefile.mk

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This is applicable to all designs.
   - FPGA On-Chip Memory
 
 ## Dependency
-* Altera Quartus Prime 25.3.1
+* Altera Quartus Prime 26.1
 * Supported Board
-  - Intel Stratix 10 SX SoC Development Kit
+  - Stratix 10 SX SoC Development Kit
 
 ## Tested Platform for the GHRD Make flow
 * SUSE Linux Enterprise Server 15 SP4
@@ -29,12 +29,17 @@ This is applicable to all designs.
 ### Baseline
 This design boots from SD/MMC.
 ```bash
-make s10-htile-soc-devkit-baseline-all
+make s10-htile-soc-devkit-oobe-baseline-all
 ```
 ### NAND
-This design boots from nand.
+This design boots from NAND.
 ```bash
-make s10-htile-soc-devkit-nand-all
+make s10-htile-soc-devkit-nand-baseline-all
+```
+### EMMC
+This design boots from EMMC.
+```bash
+make s10-htile-soc-devkit-emmc-baseline-all
 ```
 
 ## Install location

--- a/s10_soc_devkit_ghrd/Makefile
+++ b/s10_soc_devkit_ghrd/Makefile
@@ -846,21 +846,6 @@ generate-s10-htile-soc-devkit-emmc-baseline:
 generate-s10-htile-soc-devkit-oobe-pcie-gen3x8:
 	make generate_from_tcl_internal QUARTUS_DEVICE=1SX280HU2F50E1VGAS BOOTS_FIRST=hps ENABLE_PCIE=1
 
-.PHONY: generate-fpga_first
-generate-fpga_first:
-	make generate_from_tcl_internal BOOTS_FIRST=fpga HPS_ENABLE_SGMII=0 ENABLE_PCIE=0 ENABLE_PARTIAL_RECONFIGURATION=0
-
-.PHONY: generate-pr
-generate-pr:
-	make generate_from_tcl_internal BOOTS_FIRST=fpga ENABLE_PARTIAL_RECONFIGURATION=1
-
-.PHONY: build-pr_alternate-rbf
-build-pr_alternate-rbf:
-	quartus_cdb ghrd_1sx280lu2f50e2vg.qpf -c ghrd_1sx280lu2f50e2vg --export_partition root_partition --snapshot final --file base_static.qdb
-	qsys-generate --quartus-project=ghrd_1sx280lu2f50e2vg.qpf --clear-output-directory --rev=alternate_persona pr_r0_per.qsys --upgrade-ip-cores
-	qsys-generate --quartus-project=ghrd_1sx280lu2f50e2vg.qpf --clear-output-directory --rev=alternate_persona pr_r0_per.qsys --synthesis=VERILOG
-	quartus_sh --flow compile ghrd_1sx280lu2f50e2vg.qpf -c alternate_persona
-
 ################################################
 
 ################################################

--- a/s10_soc_devkit_ghrd/README.md
+++ b/s10_soc_devkit_ghrd/README.md
@@ -15,27 +15,21 @@ This design boots from SD/MMC.
 ```bash
 make generate-s10-htile-soc-devkit-oobe-baseline
 ```
-### HPS Serial Gigabit Media Independent Interface (SGMII)
-This design boots from SD/MMC and enabled SGMII with HPS EMAC and 1G/2.5G/5G/10G Multi-Rate Ethernet PHY Intel FPGA IP
-```bash
-make generate-s10-htile-soc-devkit-oobe-sgmii
-```
 ### NAND
-This design boots from nand.
+This design boots from NAND.
 ```bash
 make generate-s10-htile-soc-devkit-nand-baseline
 ```
-### PCIe Gen3x8
-This design boots from SD/MMC and has PCIe RootPort IP.
-Refer: [L-Tile and H-Tile Avalon Memory-mapped Intel FPGA IP for PCI Express* User Guide](https://www.intel.com/content/www/us/en/docs/programmable/683667/23-4/introduction.html) and [Stratix 10 PCIe Root Port with MSI](https://www.rocketboards.org/foswiki/Projects/Stratix10PCIeRootPortWithMSI) for more information.
+### EMMC
+This design boots from EMMC.
 ```bash
-make generate-s10-htile-soc-devkit-oobe-pcie-gen3x8
+make generate-s10-htile-soc-devkit-emmc-baseline
 ```
 
 ## GHRD Overview
 
 ### Hard Processor System (HPS)
-The GHRD HPS configuration matches the board schematic. Refer to [Stratix 10 Hard Processor System Technical Reference Manual](https://www.intel.com/content/www/us/en/docs/programmable/683222/current) and [Intel Stratix 10 Hard Processor System Component Reference Manual](https://www.intel.com/content/www/us/en/docs/programmable/683516/current) for more information on HPS configuration.
+The GHRD HPS configuration matches the board schematic. Refer to [Stratix 10 Hard Processor System Technical Reference Manual](https://www.intel.com/content/www/us/en/docs/programmable/683222/current) and [Stratix 10 Hard Processor System Component Reference Manual](https://www.intel.com/content/www/us/en/docs/programmable/683516/current) for more information on HPS configuration.
 
 ### HPS External Memory Interfaces (EMIF)
 The GHRD HPS EMIF configuration matches the board schematic. Refer to
@@ -44,7 +38,7 @@ The GHRD HPS EMIF configuration matches the board schematic. Refer to
 ### HPS-to-FPGA Address Map for all designs
 The MPU region provide windows of 4 GB into the FPGA slave address space. The lower 1.5 GB of this space is mapped to two separate addresses - firstly from 0x8000_0000 to 0xDFFF_FFFF and secondly from 0x20_0000_0000 to 0x20_5FFF_FFFF. The following table lists the offset of each peripheral from the HPS-to-FPGA bridge in the FPGA portion of the SoC.
 
-Refer to [Intel Stratix 10 Hard Processor System Address Map and Register Definitions](https://www.intel.com/content/www/us/en/programmable/hps/stratix-10/hps.html) for details.
+Refer to [Stratix 10 Hard Processor System Address Map and Register Definitions](https://www.intel.com/content/www/us/en/programmable/hps/stratix-10/hps.html) for details.
 
 | Peripheral | Address Offset | Size (bytes) | Attribute |
 | :-- | :-- | :-- | :-- |
@@ -95,7 +89,7 @@ The Address Map for this design is consolidated in this section.
 #### HPS-to-FPGA Address Map for PCIe design
 The MPU region provide windows of 4 GB into the FPGA slave address space. The lower 1.5 GB of this space is mapped to two separate addresses - firstly from 0x8000_0000 to 0xDFFF_FFFF and secondly from 0x20_0000_0000 to 0x20_5FFF_FFFF. The following table lists the offset of each peripheral from the HPS-to-FPGA bridge in the FPGA portion of the SoC.
 
-Refer to [Intel Stratix 10 Hard Processor System Address Map and Register Definitions](https://www.intel.com/content/www/us/en/programmable/hps/stratix-10/hps.html) for details.
+Refer to [Stratix 10 Hard Processor System Address Map and Register Definitions](https://www.intel.com/content/www/us/en/programmable/hps/stratix-10/hps.html) for details.
 
 | Peripheral | Address Offset | Size (bytes) | Attribute |
 | :-- | :-- | :-- | :-- |


### PR DESCRIPTION
## Release Information:
Quartus Version: 26.1 Build 110 03/26/2026 SC Pro Edition
Tag: QPDS26.1_REL_GSRD_PR
Build: socfpga_ghrd_s10_base/26.1/499

## New Features and Enhancements
- New design support for eMMC binaries boot for Stratix 10 H-Tile Development Kit (DK-SOC-1SSX-H-D)

## Issues Resolved
None

## Latest Known Issues
None